### PR TITLE
add argument to specify log directory

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -51,6 +51,8 @@ Optional:
   --master URI
                Master to launch the job against, especially important for upstart
                jobs on secondary machines. Defaults to http://$ROS_IP:11311
+  --logdir DIRECTORY
+               Path/to/directory where logfiles should be stored. Defaults to /tmp
   --augment    Skip creating a job-- just copy the indicated launchfiles. Useful
                adding more launchers to a single job, in the case of multiple
                potential configurations.
@@ -62,7 +64,7 @@ EOF
 )
 if [[ "$@" =~ "--help" || "$#" == "0" ]]; then echo "$usage"; exit 0; fi
 
-tmpl_arg_names=(job interface user setup rosdistro master)
+tmpl_arg_names=(job interface user setup rosdistro master logdir)
 
 ##############################################################################
 # Reinvocation as root
@@ -128,6 +130,7 @@ pkgpath=`echo ${positionals[0]} | cut -d/ -f2-`
 job=${job-`echo "$pkg" | cut -d_ -f1`}
 interface=${interface-"eth0"}
 master=${master-"http://\$ROS_IP:11311"}
+logdir=${logdir-"/tmp"}
 
 ##############################################################################
 # Installation details

--- a/tmpl/start
+++ b/tmpl/start
@@ -35,20 +35,27 @@ log info "{job}: Using workspace setup file {setup}"
 source {setup}
 JOB_FOLDER=/etc/ros/{rosdistro}/{job}.d 
 
+logdir={logdir}
 export ROS_IP=`rosrun robot_upstart getifip {interface}`
 export ROS_MASTER_URI={master}
 if [ "$ROS_IP" = "" ]; then
   log err "{job}: No IP address on {interface}, cannot roslaunch."
   exit 1
 fi
-log info "{job}: Launching on interface {interface}, ROS_IP=$ROS_IP, ROS_MASTER_URI=$ROS_MASTER_URI"
+
+if [[ ! -d $logdir ]]; then
+  log warn "{job}: The log directory you specified ($logdir) does not exist. Defaulting to /tmp!"
+  logdir="/tmp"
+fi
+
+log info "{job}: Launching on interface {interface}, ROS_IP=$ROS_IP, ROS_MASTER_URI=$ROS_MASTER_URI, ROS_LOG_DIR=$logdir"
 
 # If xacro files are present in job folder, generate and expand an amalgamated urdf.
-XACRO_FILENAME=/tmp/{job}.xacro
+XACRO_FILENAME=$logdir/{job}.xacro
 XACRO_ROBOT_NAME=$(echo "{job}" | cut -d- -f1)
 rosrun robot_upstart mkxacro $JOB_FOLDER $XACRO_ROBOT_NAME > $XACRO_FILENAME
 if [[ "$?" == "0" ]]; then
-  URDF_FILENAME=/tmp/{job}.urdf
+  URDF_FILENAME=$logdir/{job}.urdf
   rosrun xacro xacro $XACRO_FILENAME -o $URDF_FILENAME
   if [[ "$?" == "0" ]]; then
     log info "{job}: Generated URDF: $URDF_FILENAME"
@@ -59,7 +66,7 @@ if [[ "$?" == "0" ]]; then
 fi
 
 # Assemble amalgamated launchfile.
-LAUNCH_FILENAME=/tmp/{job}.launch
+LAUNCH_FILENAME=$logdir/{job}.launch
 rosrun robot_upstart mklaunch $JOB_FOLDER > $LAUNCH_FILENAME
 if [[ "$?" != "0" ]]; then
   log err "{job}: Unable to generate amalgamated launchfile."
@@ -76,11 +83,11 @@ fi
 
 # Punch it.
 export ROS_HOME=$(echo ~{user})/.ros
-export ROS_LOG_DIR=/tmp
+export ROS_LOG_DIR=$logdir
 setuidgid {user} roslaunch $LAUNCH_FILENAME &
 PID=$!
 
-log info "{job}: Started roslaunch as background process, PID $PID"
-echo "$PID" > /tmp/{job}.pid
+log info "{job}: Started roslaunch as background process, PID $PID, ROS_LOG_DIR=$ROS_LOG_DIR"
+echo "$PID" > $logdir/{job}.pid
 
 wait "$PID"

--- a/tmpl/stop
+++ b/tmpl/stop
@@ -27,6 +27,6 @@
 # 
 # Please send comments, questions, or patches to code@clearpathrobotics.com 
 
-PID=$(cat /tmp/{job}.pid)
+PID=$(cat {logdir}/{job}.pid)
 logger -p user.info "Attempting to stop {job} (PID $PID)"
 kill $PID


### PR DESCRIPTION
This PR allows a user to specify a "--logdir LOGDIRECTORY" argument to choose a user specific directory for the ros log files.
The directory needs to exist, otherwise it defaults to /tmp. This is also the default value, if the "--logdir" argument is omitted.

Maybe improves, if not solves, on #4 
