### PR TITLE
fix invalid range error on grep

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -100,7 +100,7 @@ positionals=()
 while (( "$#" )) ; do
   arg_name=`echo "$1" | grep -o ^--[a-zA-Z0-9_]*$ | cut -d- -f3`
   if [ "$arg_name" != "" ] ; then 
-    arg_val=`echo "$2" | grep -o ^[a-zA-Z0-9_-/.:]*$`
+    arg_val=`echo "$2" | grep -o ^[a-zA-Z0-9_/.:-]*$`
     #echo "Parsed $arg_name $arg_val"
     if [[ "$arg_val" == --* ]] || [[ "$arg_val" == "" ]]; then
       eval "$arg_name=\"true\""


### PR DESCRIPTION
`rosrun robot_upstart install turtlebot_bringup/launch/minimal.launch --interface wlan0` described in http://wiki.ros.org/robot_upstart did not work due to http://stackoverflow.com/questions/26754181/greps-invalid-range-end-bug-or-feature

```
If you want to match the character -, among others, just add it in the edges of the expression: as the first or last item.
```
