### PR TITLE
use LANG=C for ifconfig

### DIFF
--- a/scripts/getifip
+++ b/scripts/getifip
@@ -27,4 +27,4 @@
 # 
 # Please send comments, questions, or patches to code@clearpathrobotics.com 
 
-echo `ifconfig $1 | grep -o 'inet addr:[^ ]*' | cut -d: -f2`
+echo `LANG=C ifconfig $1 | grep -o 'inet addr:[^ ]*' | cut -d: -f2`


### PR DESCRIPTION
When LANG is not C (e.g. ja_JP.UTF-8), this line does not work.
