### PR TITLE
Logdir Handling

### DIFF
--- a/tmpl/start
+++ b/tmpl/start
@@ -49,6 +49,8 @@ if [[ ! -d $logdir ]]; then
   trap 'CREATED_LOGDIR=false' ERR
     log warn "{job}: The log directory you specified \"$logdir\" does not exist. I'll try to create it!"
     mkdir -p $logdir 2>/dev/null
+    chown {user}:{user} $logdir 2>/dev/null
+    chmod ug+wr $logdir 2>/dev/null
   trap - ERR
   # if logdir could not be created, default to tmp
   if [[ $CREATED_LOGDIR == false ]]; then

--- a/tmpl/start
+++ b/tmpl/start
@@ -44,8 +44,17 @@ if [ "$ROS_IP" = "" ]; then
 fi
 
 if [[ ! -d $logdir ]]; then
-  log warn "{job}: The log directory you specified ($logdir) does not exist. Defaulting to /tmp!"
-  logdir="/tmp"
+  # if logdir does not exist, try to create it
+  CREATED_LOGDIR=true
+  trap 'CREATED_LOGDIR=false' ERR
+    log warn "{job}: The log directory you specified \"$logdir\" does not exist. I'll try to create it!"
+    mkdir -p $logdir 2>/dev/null
+  trap - ERR
+  # if logdir could not be created, default to tmp
+  if [[ $CREATED_LOGDIR == false ]]; then
+    log warn "{job}: The log directory you specified \"$logdir\" cannot be created. Defaulting to \"/tmp\"!"
+    logdir="/tmp"
+  fi
 fi
 
 log info "{job}: Launching on interface {interface}, ROS_IP=$ROS_IP, ROS_MASTER_URI=$ROS_MASTER_URI, ROS_LOG_DIR=$logdir"


### PR DESCRIPTION
We require the `logdir` to be created automatically, if it is not there. This is due to the fact that we cannot guarantee the log directory to exist, but we don't want to loose the log files over reboots.

If `logdir` does not exist, try to create it (with correct ownership/permissions) instead of falling back to `/tmp`.
Only if this fails, fall back to `/tmp`.

Using the `trap` command here is not really nice, but serves the purpose. 

What do you think?
(Yeah, we're still on hydro for this one ;-) )
