### PR TITLE
Uninstall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,13 @@ find_package(catkin REQUIRED COMPONENTS roslint)
 catkin_package()
 catkin_python_setup()
 
-roslint_python()
-roslint_add_test()
-
 file(GLOB SCRIPTS scripts/*)
 install(PROGRAMS ${SCRIPTS} DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 install(DIRECTORY templates DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+roslint_python()
+
+if (CATKIN_ENABLE_TESTING)
+  roslint_add_test()
+  catkin_add_nosetests(test)
+endif()

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,6 +8,7 @@ to start your robot's ROS launch files when its PC powers up.
     :hidden:
 
     install
+    uninstall
     jobs
     providers
 
@@ -38,7 +39,7 @@ being output to the terminal on startup, check the upstart log:
 
     $ sudo tail /var/log/upstart/myrobot.log -n 30
 
-For more details, please see :doc:`install`.
+For more details, please see :doc:`install` and :doc:`uninstall`.
 
 
 Python API

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,6 +6,7 @@ The ``install`` script
     :func: get_argument_parser
     :prog: install
 
+
 Permissions
 -----------
 

--- a/doc/uninstall.rst
+++ b/doc/uninstall.rst
@@ -1,0 +1,28 @@
+The ``uninstall`` script
+======================
+
+.. argparse::
+    :module: robot_upstart.uninstall_script
+    :func: get_argument_parser
+    :prog: uninstall
+
+Caveats
+-------
+
+The uninstall script (and underlying method) make few guarantees--- all that ``uinstall`` will do
+is attempt to remove the files which were recorded as created by the last-run ``install`` action.
+It's not able to remove files added manually to a job after installation, nor can it detect and
+warn about modifications made to files.
+
+If the installed files are moved or the ``.installed_files`` manifest file is not intact,
+uninstallation will fail.
+
+
+Implementation
+--------------
+
+You can find this script's implementation in the
+:func:`robot_upstart.uninstall_script.main` function.
+
+.. automodule:: robot_upstart.uninstall_script
+    :members:

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <run_depend>daemontools</run_depend>
   <run_depend>roslaunch</run_depend>
   <run_depend>xacro</run_depend>
+  <test_depend>rosunit</test_depend>
 
   <export>
     <architecture_independent/>

--- a/scripts/mutate_files
+++ b/scripts/mutate_files
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD)
+#
+# @author    Mike Purvis <mpurvis@clearpathrobotics.com>
+# @copyright (c) 2015, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+# the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+#   following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+#   following disclaimer in the documentation and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or
+#   promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+This script is called by the Job.install method. Its purpose is to be passed a small recipe
+of files to be created as the root user. So this script may be invoked under sudo while the
+majority of the installation process occurs as the unprivileged user.
+"""
+
+import os, pickle, sys
+
+if len(sys.argv) != 2:
+    print "This script is not intended to be called manually."
+    exit(1)
+
+installation_files = pickle.loads(sys.argv[1])
+
+# Check first for writability, creating paths if necessary.
+paths = set([os.path.dirname(filename) for filename in installation_files.keys()])
+
+for path in paths:
+    if os.path.exists(path):
+        if not os.access(path, os.W_OK | os.X_OK):
+            print "Unable to write to path: %s" % path
+            exit(1)
+    else:
+        try:
+            os.makedirs(path)
+        except:
+            print "Unable to create path: %s" % path
+
+# Create the files according to the pickled spec.
+for filename in installation_files.keys():
+    recipe = installation_files[filename]
+
+    if 'content' in recipe:
+        with open(filename, 'w') as f:
+            f.write(recipe['content'])
+
+    if 'mode' in recipe:
+        os.chmod(filename, recipe['mode'])
+
+    if 'remove' in recipe and recipe['remove']:
+        os.remove(filename)
+
+exit(0)

--- a/scripts/mutate_files
+++ b/scripts/mutate_files
@@ -23,9 +23,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 """
-This script is called by the Job.install method. Its purpose is to be passed a small recipe
-of files to be created as the root user. So this script may be invoked under sudo while the
-majority of the installation process occurs as the unprivileged user.
+This script is called by the Job.install and Job.uninstall methods. Its purpose is to be passed a
+small recipe of files to be created as the root user. So this script may be invoked under sudo
+while the majority of the installation process occurs as the unprivileged user.
 """
 
 import os, pickle, sys
@@ -50,18 +50,28 @@ for path in paths:
         except:
             print "Unable to create path: %s" % path
 
-# Create the files according to the pickled spec.
-for filename in installation_files.keys():
-    recipe = installation_files[filename]
+# Mutate files according to the provided spec. We sort the list in reverse length
+# order so that when we are trying to remove a directory it is after everything in
+# it has already been removed.
+paths = installation_files.keys()
+paths.sort(key=len, reverse=True)
+for path in paths:
+    recipe = installation_files[path]
 
     if 'content' in recipe:
-        with open(filename, 'w') as f:
+        with open(path, 'w') as f:
             f.write(recipe['content'])
 
     if 'mode' in recipe:
-        os.chmod(filename, recipe['mode'])
+        os.chmod(path, recipe['mode'])
 
     if 'remove' in recipe and recipe['remove']:
-        os.remove(filename)
+        if os.path.isdir(path):
+            try:
+                os.rmdir(path)
+            except OSError:
+                print "WARNING: Unable to remove directory %s. Additional user-added files may be present." % path
+        else:
+            os.remove(path)
 
 exit(0)

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Software License Agreement (BSD) 
+# Software License Agreement (BSD)
 #
 # @author    Mike Purvis <mpurvis@clearpathrobotics.com>
 # @copyright (c) 2015, Clearpath Robotics, Inc., All rights reserved.
@@ -23,42 +23,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 """
-This script is called by the Job.install method. Its purpose is to be passed a small recipe
-of files to be created as the root user. So this script may be invoked under sudo while the
-majority of the installation process occurs as the unprivileged user.
+The is the uninstall CLI interface to the robot_upstart package.
 """
 
-import os, pickle, sys
+from robot_upstart.uninstall_script import main
 
-if len(sys.argv) != 2:
-    print "This script is not intended to be called manually."
-    exit(1)
-
-installation_files = pickle.loads(sys.argv[1])
-
-# Check first for writability, creating paths if necessary.
-paths = set([os.path.dirname(filename) for filename in installation_files.keys()])
-
-for path in paths:
-    if os.path.exists(path):
-        if not os.access(path, os.W_OK | os.X_OK):
-            print "Unable to write to path: %s" % path
-            exit(1)
-    else:
-        try:
-            os.makedirs(path)
-        except:
-            print "Unable to create path: %s" % path
-
-# Create the files according to the pickled spec.
-for filename in installation_files.keys():
-    recipe = installation_files[filename]
-
-    if 'content' in recipe:
-        with open(filename, 'w') as f:
-            f.write(recipe['content'])
-
-    if 'mode' in recipe:
-        os.chmod(filename, recipe['mode']) 
-
-exit(0)
+if __name__ == "__main__":
+    exit(main())

--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -78,7 +78,7 @@ def main():
 
     found_path = find_in_workspaces(project=pkg, path=pkgpath, first_match_only=True)
     if not found_path:
-        print "Unable to located path %s in package %s. Installation aborted." % (pkgpath, pkg)
+        print "Unable to locate path %s in package %s. Installation aborted." % (pkgpath, pkg)
 
     if os.path.isfile(found_path[0]):
         # Single file, install just that.

--- a/src/robot_upstart/job.py
+++ b/src/robot_upstart/job.py
@@ -153,23 +153,52 @@ class Job(object):
         # passed to a sudo process so that it can create the actual files,
         # without needing a ROS workspace or any other environmental setup.
         p = Provider(root, self)
-        installation_files = p.generate()
-
-        try:
-            # Installed script location
-            create_files_exec = find_in_workspaces(
-                project="robot_upstart", path="create_files", first_match_only=True)[0]
-        except IndexError:
-            # Devel script location
-            create_files_exec = find_in_workspaces(
-                project="robot_upstart", path="scripts/create_files", first_match_only=True)[0]
+        installation_files = p.generate_install()
 
         print "Preparing to install files to the following paths:"
         for filename in sorted(installation_files.keys()):
             print "  %s" % filename
 
+        self._call_mutate(sudo, installation_files)
+
+    def uninstall(self, root="/", sudo="/usr/bin/sudo", Provider=providers.Upstart):
+        """ Uninstall the job definition from the system.
+
+        :param root: Override the root to uninstall from, useful for testing.
+        :type root: str
+        :param sudo: Override which sudo is used, useful for testing or for making
+            it use gksudo instead.
+        :type sudo: str
+        :param provider: Override to use your own generator function for the system
+            file preparation.
+        :type provider: Provider
+        """
+
+        p = Provider(root, self)
+        installation_files = p.generate_uninstall()
+
+        if len(installation_files) == 0:
+            print "Job not found, nothing to remove."
+        else:
+            print "Preparing to remove files from the following paths:"
+            for filename in sorted(installation_files.keys()):
+                print "  %s" % filename
+
+            if (self._call_mutate(sudo, installation_files) == 0):
+                print "Note that created paths have not been removed, nor have additional launch files you may have added."
+
+    def _call_mutate(self, sudo, installation_files):
+        try:
+            # Installed script location
+            mutate_files_exec = find_in_workspaces(
+                project="robot_upstart", path="mutate_files", first_match_only=True)[0]
+        except IndexError:
+            # Devel script location
+            mutate_files_exec = find_in_workspaces(
+                project="robot_upstart", path="scripts/mutate_files", first_match_only=True)[0]
+
         # If sudo is specified, then the user will be prompted at this point.
-        cmd = [create_files_exec]
+        cmd = [mutate_files_exec]
         if sudo:
             cmd.insert(0, sudo)
         print "Now calling: %s" % ' '.join(cmd)
@@ -177,6 +206,10 @@ class Job(object):
         p.communicate()
 
         if p.returncode == 0:
-            print "Installation of files succeeded."
+            print "Filesystem operation succeeded."
         else:
-            print "Error encountered installing files."
+            print "Error encountered; filesystem operation aborted."
+
+        return p.returncode
+
+

--- a/src/robot_upstart/job.py
+++ b/src/robot_upstart/job.py
@@ -180,12 +180,11 @@ class Job(object):
         if len(installation_files) == 0:
             print "Job not found, nothing to remove."
         else:
-            print "Preparing to remove files from the following paths:"
+            print "Preparing to remove the following paths:"
             for filename in sorted(installation_files.keys()):
                 print "  %s" % filename
 
-            if (self._call_mutate(sudo, installation_files) == 0):
-                print "Note that created paths have not been removed, nor have additional launch files you may have added."
+            self._call_mutate(sudo, installation_files)
 
     def _call_mutate(self, sudo, installation_files):
         try:

--- a/src/robot_upstart/providers.py
+++ b/src/robot_upstart/providers.py
@@ -85,6 +85,17 @@ class Upstart(Generic):
                 "content": self._fill_template("templates/job-stop.em"), "mode": 0o755}
             self.interpreter.shutdown()
 
+        # Add an annotation file listing what has been installed. This is a union of what's being
+        # installed now with what has been installed previously, so that an uninstall should remove
+        # all of it.
+        installed_files_set = set(installation_files.keys())
+        installed_files_set_location = os.path.join(self.job.job_path, ".installed_files")
+        if os.exists(installed_files_set_location):
+            with open(installed_files_set_location) as f:
+                installed_files_set.extend(f.read().split("\n"))
+        installation_files[installed_files_set_location] = {
+            "content": "\n".join(installed_files_set)}
+
         return installation_files
 
     def _fill_template(self, template):

--- a/src/robot_upstart/providers.py
+++ b/src/robot_upstart/providers.py
@@ -52,6 +52,25 @@ class Generic(object):
         self.root = root
         self.job = job
 
+        # Recipe structure which is serialized to yaml and passed to the mutate_files script.
+        self.installation_files = {}
+
+        # Bare list of files, stored in the .installed_files manifest file.
+        self.installed_files_set = set()
+
+    def _add_job_files(self):
+        # Make up list of files to copy to system locations.
+        for filename in self.job.files:
+            with open(filename) as f:
+                dest_filename = os.path.join(self.job.job_path, os.path.basename(filename))
+                self.installation_files[dest_filename] = {"content": f.read()}
+
+    def _load_installed_files_set(self):
+        self.installed_files_set_location = os.path.join(self.job.job_path, ".installed_files")
+        if os.path.exists(self.installed_files_set_location):
+            with open(self.installed_files_set_location) as f:
+                self.installed_files_set.update(f.read().split("\n"))
+
 
 class Upstart(Generic):
     """ The Upstart implementation places the user-specified files in ``/etc/ros/DISTRO/NAME.d``,
@@ -60,16 +79,12 @@ class Upstart(Generic):
     ``/usr/sbin``.
     """
 
-    def generate(self):
-        self.job.job_path = os.path.join(
-            self.root, "etc/ros", self.job.rosdistro, self.job.name + ".d")
+    def generate_install(self):
+        # Default for Upstart is /etc/ros/JOBNAME.d
+        self._set_job_path()
 
-        # Make up list of files to copy to system locations.
-        installation_files = {}
-        for filename in self.job.files:
-            with open(filename) as f:
-                dest_filename = os.path.join(self.job.job_path, os.path.basename(filename))
-                installation_files[dest_filename] = {"content": f.read()}
+        # User-specified launch files.
+        self._add_job_files()
 
         # This is optional to support the old --augment flag where a "job" only adds
         # launch files to an existing configuration.
@@ -77,26 +92,38 @@ class Upstart(Generic):
             # Share a single instance of the empy interpreter.
             self.interpreter = em.Interpreter(globals=self.job.__dict__.copy())
 
-            installation_files[os.path.join(self.root, "etc/init", self.job.name + ".conf")] = {
+            self.installation_files[os.path.join(self.root, "etc/init", self.job.name + ".conf")] = {
                 "content": self._fill_template("templates/job.conf.em"), "mode": 0o644}
-            installation_files[os.path.join(self.root, "usr/sbin", self.job.name + "-start")] = {
+            self.installation_files[os.path.join(self.root, "usr/sbin", self.job.name + "-start")] = {
                 "content": self._fill_template("templates/job-start.em"), "mode": 0o755}
-            installation_files[os.path.join(self.root, "usr/sbin", self.job.name + "-stop")] = {
+            self.installation_files[os.path.join(self.root, "usr/sbin", self.job.name + "-stop")] = {
                 "content": self._fill_template("templates/job-stop.em"), "mode": 0o755}
             self.interpreter.shutdown()
 
         # Add an annotation file listing what has been installed. This is a union of what's being
         # installed now with what has been installed previously, so that an uninstall should remove
-        # all of it.
-        installed_files_set = set(installation_files.keys())
-        installed_files_set_location = os.path.join(self.job.job_path, ".installed_files")
-        if os.exists(installed_files_set_location):
-            with open(installed_files_set_location) as f:
-                installed_files_set.extend(f.read().split("\n"))
-        installation_files[installed_files_set_location] = {
-            "content": "\n".join(installed_files_set)}
+        # all of it. A more sophisticated future implementation could track contents or hashes and
+        # thereby warn users when a new installation is stomping a change they have made.
+        self._load_installed_files_set()
+        self.installed_files_set.update(self.installation_files.keys())
+        self.installed_files_set.add(self.installed_files_set_location)
+        self.installation_files[self.installed_files_set_location] = {
+            "content": "\n".join(self.installed_files_set)}
 
-        return installation_files
+        return self.installation_files
+
+    def generate_uninstall(self):
+        self._set_job_path()
+        self._load_installed_files_set()
+
+        for filename in self.installed_files_set:
+            self.installation_files[filename] = { "remove": True }
+
+        return self.installation_files
+
+    def _set_job_path(self):
+        self.job.job_path = os.path.join(
+            self.root, "etc/ros", self.job.rosdistro, self.job.name + ".d")
 
     def _fill_template(self, template):
         self.interpreter.output = StringIO.StringIO()
@@ -104,3 +131,4 @@ class Upstart(Generic):
         with open(find_in_workspaces(project="robot_upstart", path=template)[0]) as f:
             self.interpreter.file(f)
             return self.interpreter.output.getvalue()
+        self.set_job_path()

--- a/src/robot_upstart/providers.py
+++ b/src/robot_upstart/providers.py
@@ -80,7 +80,7 @@ class Upstart(Generic):
     """
 
     def generate_install(self):
-        # Default for Upstart is /etc/ros/JOBNAME.d
+        # Default for Upstart is /etc/ros/DISTRO/JOBNAME.d
         self._set_job_path()
 
         # User-specified launch files.
@@ -106,7 +106,13 @@ class Upstart(Generic):
         # thereby warn users when a new installation is stomping a change they have made.
         self._load_installed_files_set()
         self.installed_files_set.update(self.installation_files.keys())
+
+        # Remove the job directory. This will fail if it is not empty, and notify the user.
+        self.installed_files_set.add(self.job.job_path)
+
+        # Remove the annotation file itself.
         self.installed_files_set.add(self.installed_files_set_location)
+
         self.installation_files[self.installed_files_set_location] = {
             "content": "\n".join(self.installed_files_set)}
 

--- a/src/robot_upstart/uninstall_script.py
+++ b/src/robot_upstart/uninstall_script.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD)
+#
+# @author    Mike Purvis <mpurvis@clearpathrobotics.com>
+# @copyright (c) 2015, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+# the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+#   following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+#   following disclaimer in the documentation and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or
+#   promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+import argparse
+import os
+
+import robot_upstart
+from catkin.find_in_workspaces import find_in_workspaces
+
+
+def get_argument_parser():
+    p = argparse.ArgumentParser(
+        description=
+        """Use this script to remove upstart jobs created by the corresponding install script.""")
+
+    p.add_argument("jobname", type=str, nargs=1, metavar=("JOBNAME",),
+                   help="Name of job to uninstall.")
+    p.add_argument("--rosdistro", type=str, metavar="DISTRO",
+                   help="Specify ROS distro this is for.")
+    return p
+
+
+def main():
+    """ Implementation of the ``uninstall`` script."""
+
+    args = get_argument_parser().parse_args()
+    j = robot_upstart.Job(name=args.jobname[0], rosdistro=args.rosdistro)
+    j.uninstall()
+
+    return 0

--- a/test/launch/a.launch
+++ b/test/launch/a.launch
@@ -1,0 +1,2 @@
+<launch>
+</launch>

--- a/test/launch/b.launch
+++ b/test/launch/b.launch
@@ -1,0 +1,2 @@
+<launch>
+</launch>

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+import em
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import robot_upstart
+
+
+class TestBasics(unittest.TestCase):
+
+    def setUp(self):
+        self.root_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.root_dir)
+
+        # A bit of extra cleanup required which doesn't happen in Interpreter.shutdown. This isn't necessary
+        # in the usual course of things where we only do one Job operation per run, but it is required for
+        # testing, where we do a bunch of them back to back.
+        em.Interpreter._wasProxyInstalled = False
+
+    def pjoin(self, *p):
+        return os.path.join(self.root_dir, *p)
+
+
+    def test_install(self):
+        j = robot_upstart.Job(name="foo")
+        j.install(sudo=None, root=self.root_dir)
+
+        self.assertTrue(os.path.exists(self.pjoin("usr/sbin/foo-start")), "Start script not created.")
+        self.assertTrue(os.path.exists(self.pjoin("usr/sbin/foo-stop")), "Stop script not created.")
+        self.assertTrue(os.path.exists(self.pjoin("etc/init/foo.conf")), "Upstart configuration file not created.")
+
+        self.assertEqual(0, subprocess.call(["bash", "-n", self.pjoin("usr/sbin/foo-start")]), "Start script not valid bash syntax.")
+        self.assertEqual(0, subprocess.call(["bash", "-n", self.pjoin("usr/sbin/foo-stop")]), "Stop script not valid bash syntax.")
+
+    def test_install_launcher(self):
+        j = robot_upstart.Job(name="bar")
+        j.add('robot_upstart', 'test/launch/a.launch')
+        j.install(sudo=None, root=self.root_dir)
+
+        self.assertTrue(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "bar.d/a.launch")), "Launch file not copied.")
+        self.assertFalse(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "bar.d/b.launch")), "Launch copied which shouldn't have been.")
+
+    def test_install_glob(self):
+        j = robot_upstart.Job(name="baz")
+        j.add('robot_upstart', glob='test/launch/*.launch')
+        j.install(sudo=None, root=self.root_dir)
+
+        self.assertTrue(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "baz.d/a.launch")), "Launch file not copied.")
+        self.assertTrue(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "baz.d/b.launch")), "Launch file not copied.")
+
+    def test_uninstall(self):
+        j = robot_upstart.Job(name="boo")
+        j.add('robot_upstart', glob='test/launch/*.launch')
+        j.install(sudo=None, root=self.root_dir)
+        j.uninstall(sudo=None, root=self.root_dir)
+
+        self.assertFalse(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "boo.d")), "Job dir not removed.")
+        self.assertFalse(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "usr/sbin/foo-start")), "Start script not removed.")
+
+    def test_uninstall_user_file(self):
+        j = robot_upstart.Job(name="goo")
+        j.add('robot_upstart', glob='test/launch/*.launch')
+        j.install(sudo=None, root=self.root_dir)
+        with open(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "goo.d/c.launch"), "w") as f:
+            f.write("<launch></launch>")
+        j.uninstall(sudo=None, root=self.root_dir)
+
+        self.assertTrue(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "goo.d/c.launch")), "User launch file wrongly removed.")
+
+
+if __name__ == '__main__':
+    import rosunit
+    rosunit.unitrun('robot_upstart', 'test_basics', TestBasics)


### PR DESCRIPTION
As in the one comment, a more sophisticated implementation could keep track of hashes and so on, but this is a good start. In short, each "install" creates a `/etc/ros/DISTRO/JOB.d/.installed_files` manifest which is simply a list of the files created or modified. The uninstall method/script looks for this file and deletes everything in the list.

It doesn't remove user-added launch files, but it does remove things added using `--augment`.

It also doesn't remove created paths. Perhaps paths which are found to be empty should be removed automatically? Is that too magical? Should created paths be kept track of?
