### PR TITLE
Updated install script to allow adding multiple launch files to a job

### DIFF
--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -37,7 +37,7 @@ def get_argument_parser():
         to access the Python API from their own setup scripts, but this exists as a simple helper, an example,
         and a compatibility shim for previous versions of robot_upstart which were bash-based.""")
 
-    p.add_argument("pkgpath", type=str, nargs=1, metavar=("pkg/path",),
+    p.add_argument("pkgpath", type=str, nargs='+', metavar="pkg/path",
                    help="Package and path to install job launch files from.")
     p.add_argument("--job", type=str,
                    help="Specify job name. If unspecified, will be constructed from package name.")
@@ -73,16 +73,19 @@ def main():
         workspace_setup=args.setup, rosdistro=args.rosdistro,
         master_uri=args.master, log_path=args.logdir)
 
-    found_path = find_in_workspaces(project=pkg, path=pkgpath, first_match_only=True)
-    if not found_path:
-        print "Unable to locate path %s in package %s. Installation aborted." % (pkgpath, pkg)
+    for this_pkgpath in args.pkgpath:
+        pkg, pkgpath = this_pkgpath.split('/', 1)
 
-    if os.path.isfile(found_path[0]):
-        # Single file, install just that.
-        j.add(package=pkg, filename=pkgpath)
-    else:
-        # Directory found, install everything within.
-        j.add(package=pkg, glob=os.path.join(pkgpath, "*"))
+        found_path = find_in_workspaces(project=pkg, path=pkgpath, first_match_only=True)
+        if not found_path:
+            print "Unable to locate path %s in package %s. Installation aborted." % (pkgpath, pkg)
+
+        if os.path.isfile(found_path[0]):
+            # Single file, install just that.
+            j.add(package=pkg, filename=pkgpath)
+        else:
+            # Directory found, install everything within.
+            j.add(package=pkg, glob=os.path.join(pkgpath, "*"))
 
     if args.augment:
         j.generate_system_files = False

--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -79,7 +79,8 @@ def main():
         found_path = find_in_workspaces(project=pkg, path=pkgpath, first_match_only=True)
         if not found_path:
             print "Unable to locate path %s in package %s. Installation aborted." % (pkgpath, pkg)
-
+            return 1
+            
         if os.path.isfile(found_path[0]):
             # Single file, install just that.
             j.add(package=pkg, filename=pkgpath)


### PR DESCRIPTION
Adjusted argparse to accept multiple `pkgpath` arguments and changed the code to loop over the resulting list and add each entry to the `Job` object.

Proposed to make the install script more convenient for users who wish to install several launch files all at once with one command.

I regenerated the documentation locally and it automatically updated to reflect this change, so I don't believe any manual changes are necessary. I am happy to make any changes if necessary though.

I would also like to have this change backported to Indigo. I'm assuming the usual procedure is to make the change on the jade-devel branch and then backport.
