### PR TITLE
Added option to add launch files as symbolic link

### DIFF
--- a/scripts/mutate_files
+++ b/scripts/mutate_files
@@ -58,8 +58,8 @@ paths.sort(key=len, reverse=True)
 for path in paths:
     recipe = installation_files[path]
 
-    if 'symbolic' in recipe:
-        os.symlink(recipe['symbolic'], path)
+    if 'symlink' in recipe:
+        os.symlink(recipe['symlink'], path)
 
     if 'content' in recipe:
         with open(path, 'w') as f:

--- a/scripts/mutate_files
+++ b/scripts/mutate_files
@@ -58,6 +58,9 @@ paths.sort(key=len, reverse=True)
 for path in paths:
     recipe = installation_files[path]
 
+    if 'symbolic' in recipe:
+        os.symlink(recipe['symbolic'], path)
+
     if 'content' in recipe:
         with open(path, 'w') as f:
             f.write(recipe['content'])

--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -55,7 +55,7 @@ def get_argument_parser():
                    help="Specify an a value for ROS_LOG_DIR in the job launch context.")
     p.add_argument("--augment", action='store_true',
                    help="Bypass creating the job, and only copy user files. Assumes the job was previously created.")
-    p.add_argument("--symbolic", action='store_true',
+    p.add_argument("--symlink", action='store_true',
                    help="Create symbolic link to job launch files instead of copying them.")
     return p
 
@@ -93,8 +93,8 @@ def main():
     if args.augment:
         j.generate_system_files = False
 
-    if args.symbolic:
-        j.symbolic = True
+    if args.symlink:
+        j.symlink = True
 
     j.install()
 

--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -55,6 +55,8 @@ def get_argument_parser():
                    help="Specify an a value for ROS_LOG_DIR in the job launch context.")
     p.add_argument("--augment", action='store_true',
                    help="Bypass creating the job, and only copy user files. Assumes the job was previously created.")
+    p.add_argument("--symbolic", action='store_true',
+                   help="Create symbolic link to job launch files instead of copying them.")
     return p
 
 
@@ -90,6 +92,9 @@ def main():
 
     if args.augment:
         j.generate_system_files = False
+
+    if args.symbolic:
+        j.symbolic = True
 
     j.install()
 

--- a/src/robot_upstart/job.py
+++ b/src/robot_upstart/job.py
@@ -93,7 +93,7 @@ class Job(object):
 
         # Override this to True if you want to create symbolic link for
         # job launch files instead of copying them.
-        self.symbolic = False
+        self.symlink = False
 
         # Override this to True is you want the --wait flag passed to roslaunch.
         # This will be desired if the nodes spawned by this job are intended to

--- a/src/robot_upstart/job.py
+++ b/src/robot_upstart/job.py
@@ -91,6 +91,10 @@ class Job(object):
         # upstart conf file.
         self.generate_system_files = True
 
+        # Override this to True if you want to create symbolic link for
+        # job launch files instead of copying them.
+        self.symbolic = False
+
         # Override this to True is you want the --wait flag passed to roslaunch.
         # This will be desired if the nodes spawned by this job are intended to
         # connect to an existing master.

--- a/src/robot_upstart/providers.py
+++ b/src/robot_upstart/providers.py
@@ -63,7 +63,10 @@ class Generic(object):
         for filename in self.job.files:
             with open(filename) as f:
                 dest_filename = os.path.join(self.job.job_path, os.path.basename(filename))
-                self.installation_files[dest_filename] = {"content": f.read()}
+                if self.job.symbolic:
+                    self.installation_files[dest_filename] = {"symbolic": filename}
+                else:
+                    self.installation_files[dest_filename] = {"content": f.read()}
 
     def _load_installed_files_set(self):
         self.installed_files_set_location = os.path.join(self.job.job_path, ".installed_files")

--- a/src/robot_upstart/providers.py
+++ b/src/robot_upstart/providers.py
@@ -61,11 +61,11 @@ class Generic(object):
     def _add_job_files(self):
         # Make up list of files to copy to system locations.
         for filename in self.job.files:
-            with open(filename) as f:
-                dest_filename = os.path.join(self.job.job_path, os.path.basename(filename))
-                if self.job.symbolic:
-                    self.installation_files[dest_filename] = {"symbolic": filename}
-                else:
+            dest_filename = os.path.join(self.job.job_path, os.path.basename(filename))
+            if self.job.symlink:
+                self.installation_files[dest_filename] = {"symlink": filename}
+            else:
+                with open(filename) as f:
                     self.installation_files[dest_filename] = {"content": f.read()}
 
     def _load_installed_files_set(self):


### PR DESCRIPTION
This pull request adds "--symbolic" option to use symbolic link to job launch files instead of copying them to separate location. This is related to Issue #24. 

Please review changes and provide feedback.
