### PR TITLE
Added "--env" option to add custom export statement in job-start

### DIFF
--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -60,6 +60,8 @@ def get_argument_parser():
                    help="Specify provider if the autodetect fails to identify the correct provider")
     p.add_argument("--symlink", action='store_true',
                    help="Create symbolic link to job launch files instead of copying them.")
+    p.add_argument("--env", nargs='*', metavar="name=value",
+                   help="Specify environment variables required during launch to be exported by the start script.")
     return p
 
 def detect_provider():
@@ -81,7 +83,7 @@ def main():
     j = robot_upstart.Job(
         name=job_name, interface=args.interface, user=args.user,
         workspace_setup=args.setup, rosdistro=args.rosdistro,
-        master_uri=args.master, log_path=args.logdir)
+        master_uri=args.master, log_path=args.logdir, environment_vars=args.env)
 
     for this_pkgpath in args.pkgpath:
         pkg, pkgpath = this_pkgpath.split('/', 1)

--- a/src/robot_upstart/job.py
+++ b/src/robot_upstart/job.py
@@ -40,7 +40,7 @@ class Job(object):
     """ Represents a ROS configuration to launch on machine startup. """
 
     def __init__(self, name="ros", interface=None, user=None, workspace_setup=None,
-                 rosdistro=None, master_uri=None, log_path=None):
+                 rosdistro=None, master_uri=None, log_path=None, environment_vars=None):
         """Construct a new Job definition.
 
         :param name: Name of job to create. Defaults to "ros", but you might
@@ -104,6 +104,10 @@ class Job(object):
         # and other user-specified configs--- nothing related to the system
         # startup job itself. List of strs.
         self.files = []
+
+        # Set of environment variables to export in the start up script.
+        # This allows launch files to have dependency on environment variables.
+        self.environment_vars = environment_vars or []
 
     def add(self, package=None, filename=None, glob=None):
         """ Add launch or other configuration files to Job.

--- a/templates/job-start.em
+++ b/templates/job-start.em
@@ -104,6 +104,8 @@ fi
 # Punch it.
 export ROS_HOME=$(echo ~@(user))/.ros
 export ROS_LOG_DIR=$log_path
+@# Generate user specified environment variables if exists
+@[for elem in environment_vars]@[if elem]export @(elem)@\n@[end if]@[end for]
 setuidgid @(user) roslaunch $LAUNCH_FILENAME @(roslaunch_wait?'--wait ')&
 PID=$!
 


### PR DESCRIPTION
When "--env" option is specified, user can add custom export statement to job-start script using "name=value" format. This option supports setting multiple environment variables. If this option is not selected, no custom export will be added to job-start.

Example usage
```bash
rosrun robot_upstart install ros_package/path/to/launch --env LIDAR_ENABLE=1
```
This will add following line to just before launching launch file in job-start.
```bash
export LIDAR_ENABLE=1
```

This option is useful when launch file depends on specific environment variable to launch optional components.

Please review and provide feedback.