### PR TITLE
Clarify the reason of the error due to wrong pkgpath passed.

### DIFF
--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -30,6 +30,10 @@ from catkin.find_in_workspaces import find_in_workspaces
 
 import providers
 
+DESC_PKGPATH = ("Make sure the path starts with the package name"
+                " (e.g. don't pass absolute path nor a path starting from"
+                " workspace top folder etc.)")
+
 
 def get_argument_parser():
     p = argparse.ArgumentParser(
@@ -39,7 +43,8 @@ def get_argument_parser():
         and a compatibility shim for previous versions of robot_upstart which were bash-based.""")
 
     p.add_argument("pkgpath", type=str, nargs='+', metavar="pkg/path",
-                   help="Package and path to install job launch files from.")
+                   help="Package and path to install job launch files from. " +
+                        DESC_PKGPATH)
     p.add_argument("--job", type=str,
                    help="Specify job name. If unspecified, will be constructed from package name.")
     p.add_argument("--interface", type=str, metavar="ethN",
@@ -80,6 +85,11 @@ def main():
 
     for this_pkgpath in args.pkgpath:
         pkg, pkgpath = this_pkgpath.split('/', 1)
+        if not pkg:
+            print("Unable to locate package your job launch is in."
+                  " Installation aborted. " + DESC_PKGPATH +
+                  "\npkgpath passed: {}.".format(pkgpath))
+            return 1
 
         found_path = find_in_workspaces(project=pkg, path=pkgpath, first_match_only=True)
         if not found_path:


### PR DESCRIPTION
**Issue**
When the path passed to pkgpath does NOT start from the path of the directory of the package your upstart launch is located at, the following error occurs, which does not provide enough info why failing.

```
$ rosrun robot_upstart install catkin_ws/src/foo/foo_support/launch/upstart.launch --user autoboot --setup /etc/ros/setup.bash
Unable to locate path src/foo/foo_support/launch/upstart.launch in package catkin_ws. Installation aborted.
Traceback (most recent call last):
  File "/opt/ros/indigo/lib/robot_upstart/install", line 32, in <module>
    exit(main())
  File "/opt/ros/indigo/lib/python2.7/dist-packages/robot_upstart/install_script.py", line 80, in main
    if os.path.isfile(found_path[0]):
      IndexError: list index out of range
```

**Solution**
In the error message, clearly instruct what path should be passed.
Also add more description to the result of "help".

**Output example**
```
$ rosrun robot_upstart install /home/ros/catkin_ws/src/foo/foo_support/launch/upstart.launch --user autoboot --setup /etc/ros/setup.bash
Unable to locate package your job launch is in. Installation aborted. Make sure the path starts with the package name (e.g. don't pass absolute path nor a path starting from workspace top folder etc.)
pkgpath passed: home/ros/foo_ws/src/foo/foo_support/launch/upstart.launch.
```
