### PR TITLE
Add support for wait flag in the install script

### DIFF
--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -66,7 +66,8 @@ def get_argument_parser():
     p.add_argument("--symlink", action='store_true',
                    help="Create symbolic link to job launch files instead of copying them.")
     p.add_argument("--wait", action='store_true',
-                help="Pass a wait flag to roslaunch.")
+                   help="Pass a wait flag to roslaunch.")
+
     return p
 
 

--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -65,6 +65,8 @@ def get_argument_parser():
                    help="Specify provider if the autodetect fails to identify the correct provider")
     p.add_argument("--symlink", action='store_true',
                    help="Create symbolic link to job launch files instead of copying them.")
+    p.add_argument("--wait", action='store_true',
+                help="Pass a wait flag to roslaunch.")
     return p
 
 
@@ -105,6 +107,8 @@ def main():
 
     if args.augment:
         j.generate_system_files = False
+    if args.wait:
+        j.roslaunch_wait = True
 
     provider = providers.detect_provider()
     if args.provider == 'upstart':


### PR DESCRIPTION
Hi!

I run into some cases where I need to pass the wait flag to the roslaunch. This merge request adds a "--wait" option that will change the job.roslaunch_wait that was already implemented.

Please let me know if there is anything else you would like to see changed. 