### PR TITLE
Add an option to wait forever for ROS_IP

### DIFF
--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -65,6 +65,8 @@ def get_argument_parser():
                    help="Specify provider if the autodetect fails to identify the correct provider")
     p.add_argument("--symlink", action='store_true',
                    help="Create symbolic link to job launch files instead of copying them.")
+    p.add_argument("--interface_loop", action='store_true',
+                   help="Wait in an endless loop for getifip to return a valid IP address.")
     return p
 
 
@@ -105,6 +107,8 @@ def main():
 
     if args.augment:
         j.generate_system_files = False
+    if args.interface_loop:
+        j.interface_loop = True
 
     provider = providers.detect_provider()
     if args.provider == 'upstart':

--- a/src/robot_upstart/job.py
+++ b/src/robot_upstart/job.py
@@ -105,6 +105,11 @@ class Job(object):
         # startup job itself. List of strs.
         self.files = []
 
+        # Override this to True if the startup script should enter an endless
+        # loop until getifip returns an IP address that is valid for ROS_IP
+        # parameter.
+        self.interface_loop = False
+
     def add(self, package=None, filename=None, glob=None):
         """ Add launch or other configuration files to Job.
 

--- a/templates/job-start.em
+++ b/templates/job-start.em
@@ -54,10 +54,19 @@ fi
 
 @[if interface]@
 export ROS_IP=`rosrun robot_upstart getifip @(interface)`
+@[if interface_loop]@
+while [ "$ROS_IP" == "" ]
+do
+  sleep 1
+  log err "Couldn't initialize network interface. Retrying."
+  export ROS_IP=`rosrun robot_upstart getifip @(interface)`
+done
+@[else]@
 if [ "$ROS_IP" = "" ]; then
   log err "@(name): No IP address on @(interface), cannot roslaunch."
   exit 1
 fi
+@[end if]@
 @[else]@
 export ROS_HOSTNAME=$(hostname)
 @[end if]@


### PR DESCRIPTION
Another thing that I've come across that I would find particularly useful. 

1. Behaviour before this pull request
If an interface name is manually specified then in the created job a call to getifip is made, if the result is an empty string then the job fails.

2. Observations
In two setups with different machines but the same components (main computer running Ubuntu 16.04, the other armbian on a single board computer), where the main computer is sharing the internet connection with the slave (IP is assigned dynamically by main computer). In about 80-90% of the cases the jobs were failing on both machines. I believe it was due to jobs starting when interface has became available but before the IP was assigned.

3. Solution
As a solution I propose an additional loop that will be constantly checking the ROS_IP of the specified interface that runs if --interface_loop is called when running an install scripts.

I'm not sure that is the cleanest approach, I'd love to hear from people that run into similar issues and how they solved them.