### PR TITLE
[CI][kinetic-devel] Update to Xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,14 @@
-sudo: required
-dist: xenial
 language: generic
+services:
+  - docker
 
 env:
-  - CI_ROS_DISTRO=kinetic CC=gcc CXX=g++
-
-before_install:
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update
-  - sudo apt-get install python-rosdep -y
-  - sudo rosdep init
-  - rosdep update
+  matrix:
+    - ROS_DISTRO="dashing"
+    - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="melodic"
 
 install:
-  - mkdir -p ~/catkin_ws/src
-  - cd ~/catkin_ws
-  - ln -s $TRAVIS_BUILD_DIR src
-  - rosdep install --from-paths src --ignore-src --rosdistro=$CI_ROS_DISTRO -y
-
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
 script:
-  - source /opt/ros/$CI_ROS_DISTRO/setup.bash
-  - catkin_make install
-  - catkin_make tests
-  - devel/env.sh catkin_make run_tests -j1
-  - catkin_test_results build
+  - .industrial_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: generic
 
 env:
-  - CI_ROS_DISTRO=indigo CC=gcc CXX=g++
+  - CI_ROS_DISTRO=kinetic CC=gcc CXX=g++
 
 before_install:
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update
   - sudo apt-get install python-rosdep -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
 
 env:
   matrix:
-    - ROS_DISTRO="dashing"
     - ROS_DISTRO="kinetic"
     - ROS_DISTRO="melodic"
 


### PR DESCRIPTION
On a PR https://github.com/clearpathrobotics/robot_upstart/pull/78 I saw [CI failure](https://travis-ci.org/clearpathrobotics/robot_upstart/builds/507510733?utm_source=github_status&utm_medium=notification) that seems to be related to platform issue. Using `trusty` for xenial-based job might not work (any more?).

```
Unpacking python-rospkg (1.1.7-100) ...
dpkg-deb: error: archive '/var/cache/apt/archives/python-rosdep_0.15.1-1_all.deb' has premature member 'control.tar.xz' before 'control.tar.gz', giving up
dpkg: error processing archive /var/cache/apt/archives/python-rosdep_0.15.1-1_all.deb (--unpack):
 subprocess dpkg-deb --control returned error exit status 2
 No apport report written because MaxReports is reached already
 Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
 Processing triggers for shared-mime-info (1.2-0ubuntu3) ...
 Processing triggers for sgml-base (1.26+nmu4ubuntu1) ...
 Errors were encountered while processing:
  /var/cache/apt/archives/python-catkin-pkg-modules_0.4.10-1_all.deb
  /var/cache/apt/archives/python-catkin-pkg_0.4.10-100_all.deb
  /var/cache/apt/archives/python-rosdistro-modules_0.7.2-1_all.deb
  /var/cache/apt/archives/python-rosdistro_0.7.2-100_all.deb
  /var/cache/apt/archives/python-rosdep_0.15.1-1_all.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
The command "sudo apt-get install python-rosdep -y" failed and exited with 100 during .
```