### PR TITLE
[doc] Clarify the logic for automated job name determination.

### DIFF
--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -46,7 +46,7 @@ def get_argument_parser():
                    help="Package and path to install job launch files from. " +
                         DESC_PKGPATH)
     p.add_argument("--job", type=str,
-                   help="Specify job name. If unspecified, will be constructed from package name.")
+                   help="Specify job name. If unspecified, will be constructed from package name (first element before underscore is taken, e.g. 'myrobot' if the package name is 'myrobot_bringup').")
     p.add_argument("--interface", type=str, metavar="ethN",
                    help="Specify network interface name to associate job with.")
     p.add_argument("--user", type=str, metavar="NAME",


### PR DESCRIPTION
Problem addressed
=================

When `--job` option is not passed to `rosrun robot_upstart install`, the job name gets determined automatically but the logic of it is not clear.

Solution to the problem
=======================

Add an explanation to the document.