### PR TITLE
Melodic compatibility: rewrite getifip to make use of iproute2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>daemontools</exec_depend>
+  <exec_depend>iproute2</exec_depend>
   <exec_depend>roslaunch</exec_depend>
   <exec_depend>xacro</exec_depend>
 

--- a/scripts/getifip
+++ b/scripts/getifip
@@ -1,4 +1,33 @@
 #!/usr/bin/env python
+#
+# Author: Ramon Wijnands <ramon@ruvu.nl>
+#         Copyright (c) 2090, RUVU, b.v.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the RUVU, b.v. nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL RUVU, b.v. BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Please send comments, questions, or patches to code@clearpathrobotics.com
+
+
 from __future__ import print_function
 
 import json

--- a/scripts/getifip
+++ b/scripts/getifip
@@ -31,16 +31,15 @@
 from __future__ import print_function
 
 import json
-import shlex
 import subprocess
 from argparse import ArgumentParser
 
-parser = ArgumentParser(description='Process some integers.')
-parser.add_argument('interface', help='an integer for the accumulator')
+parser = ArgumentParser(description='Show the IP address assigned to a specific network interface')
+parser.add_argument('interface', help='name of interface')
 
 args = parser.parse_args()
 
-cmd = shlex.split("ip -json -4 addr show") + [args.interface]
+cmd = ['ip', '-json', '-4', 'addr', 'show', args.interface]
 output = subprocess.check_output(cmd)
 
 # Print the first ip address for this interface

--- a/scripts/getifip
+++ b/scripts/getifip
@@ -1,30 +1,23 @@
-#!/bin/bash
-#
-# Author: Mike Purvis <mpurvis@clearpathrobotics.com>
-#         Copyright (c) 2013, Clearpath Robotics, Inc.
-# 
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#    * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#    * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#    * Neither the name of Clearpath Robotics, Inc. nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# 
-# Please send comments, questions, or patches to code@clearpathrobotics.com 
+#!/usr/bin/env python
+from __future__ import print_function
 
-echo `LANG=C ifconfig $1 | grep -o 'inet addr:[^ ]*' | cut -d: -f2`
+import json
+import shlex
+import subprocess
+from argparse import ArgumentParser
+
+parser = ArgumentParser(description='Process some integers.')
+parser.add_argument('interface', help='an integer for the accumulator')
+
+args = parser.parse_args()
+
+cmd = shlex.split("ip -json -4 addr show") + [args.interface]
+output = subprocess.check_output(cmd)
+
+# Print the first ip address for this interface
+for iface in json.loads(output):
+    addr_info = iface['addr_info']
+    for addr in addr_info:
+        if addr:
+            print(addr['local'])
+            break

--- a/scripts/getifip
+++ b/scripts/getifip
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Author: Ramon Wijnands <ramon@ruvu.nl>
-#         Copyright (c) 2090, RUVU, b.v.
+#         Copyright (c) 2019, RUVU, b.v.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
ifconfig is deprecated in favor of iproute2. So I rewrote the script to parse the json output of the `ip route addr show <INTERFACE>` command.

This should also work for lower versions of ubuntu, but I did not test those.