### PR TITLE
Fix running tests on both 14.04 and 16.04

### DIFF
--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -33,7 +33,13 @@ class TestBasics(unittest.TestCase):
 
         self.assertTrue(os.path.exists(self.pjoin("usr/sbin/foo-start")), "Start script not created.")
         self.assertTrue(os.path.exists(self.pjoin("usr/sbin/foo-stop")), "Stop script not created.")
-        self.assertTrue(os.path.exists(self.pjoin("etc/init/foo.conf")), "Upstart configuration file not created.")
+
+        Provider = robot_upstart.providers.detect_provider()
+        if Provider == robot_upstart.providers.Upstart:
+            self.assertTrue(os.path.exists(self.pjoin("etc/init/foo.conf")), "Upstart configuration file not created.")
+        elif Provider == robot_upstart.providers.Systemd:
+            self.assertTrue(os.path.exists(self.pjoin("etc/systemd/system/multi-user.target.wants/foo.service")),
+                            "Systemd configuration file not created.")
 
         self.assertEqual(0, subprocess.call(["bash", "-n", self.pjoin("usr/sbin/foo-start")]),
                          "Start script not valid bash syntax.")


### PR DESCRIPTION
On 16.04 systemd files are generated. We can reuse
robot_upstart.providers.detect_provider() to check in the unit tests
what files are expected.

Without this patch, the unit tests on 16.04 generate the following output:
```
nosetests test/
F...WARNING: Unable to remove directory /tmp/tmpvVSrRh/etc/ros/kinetic/goo.d. Additional user-added files may be present.
.
======================================================================
FAIL: test_install (test_basics.TestBasics)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ramon/repos/robot_upstart/test/test_basics.py", line 36, in test_install
    self.assertTrue(os.path.exists(self.pjoin("etc/init/foo.conf")), "Upstart configuration file not created.")
AssertionError: Upstart configuration file not created.
-------------------- >> begin captured stdout << ---------------------
/lib/systemd/systemd
Preparing to install files to the following paths:
  /tmp/tmpO59C4y/etc/ros/kinetic/foo.d/.installed_files
  /tmp/tmpO59C4y/etc/systemd/system/multi-user.target.wants/foo.service
  /tmp/tmpO59C4y/lib/systemd/system/foo.service
  /tmp/tmpO59C4y/usr/sbin/foo-start
  /tmp/tmpO59C4y/usr/sbin/foo-stop
Now calling: /opt/ros/kinetic/lib/robot_upstart/mutate_files
Filesystem operation succeeded.
** To complete installation please run the following command:
 sudo systemctl daemon-reload && sudo systemctl start foo

--------------------- >> end captured stdout << ----------------------

----------------------------------------------------------------------
Ran 5 tests in 0.448s

FAILED (failures=1)
```