### PR TITLE
Melodic compatibility: modify getifip for bionic output

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>daemontools</exec_depend>
+  <exec_depend>net-tools</exec_depend>
   <exec_depend>roslaunch</exec_depend>
   <exec_depend>xacro</exec_depend>
 

--- a/scripts/getifip
+++ b/scripts/getifip
@@ -27,4 +27,4 @@
 # 
 # Please send comments, questions, or patches to code@clearpathrobotics.com 
 
-echo `LANG=C ifconfig $1 | grep -o 'inet addr:[^ ]*' | cut -d: -f2`
+echo `LANG=C ifconfig $1 | perl -lne '/inet (addr:)?(.[^ ]+)/ && print $2'`


### PR DESCRIPTION
This is a different approach than https://github.com/clearpathrobotics/robot_upstart/pull/83 to get melodic compatibility.

We still use `ifconfig`, but I've modified the regex to handle the output of both distros. I've chosen for perl to print regex group 2 easily.

What do you think, is this a better approach?