### PR TITLE
Change systemd dependency to network-online.target

### DIFF
--- a/templates/systemd_job.conf.em
+++ b/templates/systemd_job.conf.em
@@ -29,7 +29,8 @@
 
 [Unit]
 Description="bringup @(name)"
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
On current systems, ordering after `network.target` just guarantees that the network service has been started, not that there's some actual configuration.