### PR TITLE
updated to work with python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ services:
 
 env:
   matrix:
-    - ROS_DISTRO="kinetic"
-    - ROS_DISTRO="melodic"
+    - ROS_DISTRO="noetic"
 
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master

--- a/doc/sphinxarg/parser.py
+++ b/doc/sphinxarg/parser.py
@@ -10,7 +10,7 @@ def parser_navigate(parser_result, path, current_path=None):
     if isinstance(path, str):
         if path == '':
             return parser_result
-        path = re.split('\s+', path)
+        path = re.split(r'\s+', path)
     current_path = current_path or []
     if len(path) == 0:
         return parser_result

--- a/scripts/install
+++ b/scripts/install
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (BSD) 
 #
 # @author    Mike Purvis <mpurvis@clearpathrobotics.com>

--- a/scripts/mutate_files
+++ b/scripts/mutate_files
@@ -31,7 +31,7 @@ while the majority of the installation process occurs as the unprivileged user.
 import os, sys, json
 
 if len(sys.argv) != 2:
-    print ("This script is not intended to be called manually.")
+    print("This script is not intended to be called manually.")
     exit(1)
 
 installation_files = json.loads(os.fsencode(sys.argv[1]))
@@ -41,13 +41,13 @@ paths = set([os.path.dirname(filename) for filename in installation_files.keys()
 for path in paths:
     if os.path.exists(path):
         if not os.access(path, os.W_OK | os.X_OK):
-            print ("Unable to write to path: %s" % path)
+            print("Unable to write to path: %s" % path)
             exit(1)
     else:
         try:
             os.makedirs(path)
         except:
-            print ("Unable to create path: %s" % path)
+            print("Unable to create path: %s" % path)
 
 # Mutate files according to the provided spec. We sort the list in reverse length
 # order so that when we are trying to remove a directory it is after everything in
@@ -66,7 +66,7 @@ for path in paths:
                 os.unlink(path)
                 os.symlink(recipe['symlink'], path)
             else:
-                print ("Unable to create symlink: %s" % path)
+                print("Unable to create symlink: %s" % path)
 
     if 'content' in recipe:
         with open(path, 'w') as f:
@@ -80,7 +80,7 @@ for path in paths:
             try:
                 os.rmdir(path)
             except OSError:
-                print ("WARNING: Unable to remove directory %s. Additional user-added files may be present." % path)
+                print("WARNING: Unable to remove directory %s. Additional user-added files may be present." % path)
         else:
             os.remove(path)
 

--- a/scripts/mutate_files
+++ b/scripts/mutate_files
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (BSD)
 #
 # @author    Mike Purvis <mpurvis@clearpathrobotics.com>
@@ -28,14 +28,13 @@ small recipe of files to be created as the root user. So this script may be invo
 while the majority of the installation process occurs as the unprivileged user.
 """
 
-import os, pickle, sys
+import os, sys, json
 
 if len(sys.argv) != 2:
     print ("This script is not intended to be called manually.")
     exit(1)
 
-installation_files = pickle.loads(sys.argv[1])
-
+installation_files = json.loads(os.fsencode(sys.argv[1]))
 # Check first for writability, creating paths if necessary.
 paths = set([os.path.dirname(filename) for filename in installation_files.keys()])
 

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (BSD)
 #
 # @author    Mike Purvis <mpurvis@clearpathrobotics.com>

--- a/src/robot_upstart/__init__.py
+++ b/src/robot_upstart/__init__.py
@@ -21,5 +21,5 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from job import Job
-import providers
+from robot_upstart.job import Job
+import robot_upstart.providers

--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (BSD)
 #
 # @author    Mike Purvis <mpurvis@clearpathrobotics.com>

--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -97,7 +97,7 @@ def main():
 
         found_path = find_in_workspaces(project=pkg, path=pkgpath, first_match_only=True)
         if not found_path:
-            print ("Unable to locate path %s in package %s. Installation aborted." % (pkgpath, pkg))
+            print("Unable to locate path %s in package %s. Installation aborted." % (pkgpath, pkg))
             return 1
 
         if os.path.isfile(found_path[0]):

--- a/src/robot_upstart/job.py
+++ b/src/robot_upstart/job.py
@@ -27,7 +27,7 @@ This file defines the Job class, which is the primary code API to robot_upstart.
 
 import getpass
 import os
-import pickle
+import json
 import subprocess
 from glob import glob as glob_files
 
@@ -161,7 +161,7 @@ class Job(object):
         p = Provider(root, self)
         installation_files = p.generate_install()
 
-        print "Preparing to install files to the following paths:"
+        print ("Preparing to install files to the following paths:")
         for filename in sorted(installation_files.keys()):
             print ("  %s" % filename)
 
@@ -188,7 +188,7 @@ class Job(object):
         if len(installation_files) == 0:
             print ("Job not found, nothing to remove.")
         else:
-            print "Preparing to remove the following paths:"
+            print ("Preparing to remove the following paths:")
             for filename in sorted(installation_files.keys()):
                 print ("  %s" % filename)
 
@@ -209,7 +209,9 @@ class Job(object):
         if sudo:
             cmd.insert(0, sudo)
         print ("Now calling: %s" % ' '.join(cmd))
-        p = subprocess.Popen(cmd + [pickle.dumps(installation_files)])
+
+        # changed to use json, as pickle gives 0-bytes error
+        p = subprocess.Popen(cmd + [json.dumps(installation_files)])
         p.communicate()
 
         if p.returncode == 0:
@@ -218,3 +220,4 @@ class Job(object):
             print ("Error encountered; filesystem operation aborted.")
 
         return p.returncode
+

--- a/src/robot_upstart/job.py
+++ b/src/robot_upstart/job.py
@@ -161,9 +161,9 @@ class Job(object):
         p = Provider(root, self)
         installation_files = p.generate_install()
 
-        print ("Preparing to install files to the following paths:")
+        print("Preparing to install files to the following paths:")
         for filename in sorted(installation_files.keys()):
-            print ("  %s" % filename)
+            print("  %s" % filename)
 
         self._call_mutate(sudo, installation_files)
         p.post_install()
@@ -186,11 +186,11 @@ class Job(object):
         installation_files = p.generate_uninstall()
 
         if len(installation_files) == 0:
-            print ("Job not found, nothing to remove.")
+            print("Job not found, nothing to remove.")
         else:
-            print ("Preparing to remove the following paths:")
+            print("Preparing to remove the following paths:")
             for filename in sorted(installation_files.keys()):
-                print ("  %s" % filename)
+                print("  %s" % filename)
 
             self._call_mutate(sudo, installation_files)
 
@@ -208,16 +208,15 @@ class Job(object):
         cmd = [mutate_files_exec]
         if sudo:
             cmd.insert(0, sudo)
-        print ("Now calling: %s" % ' '.join(cmd))
+        print("Now calling: %s" % ' '.join(cmd))
 
         # changed to use json, as pickle gives 0-bytes error
         p = subprocess.Popen(cmd + [json.dumps(installation_files)])
         p.communicate()
 
         if p.returncode == 0:
-            print ("Filesystem operation succeeded.")
+            print("Filesystem operation succeeded.")
         else:
-            print ("Error encountered; filesystem operation aborted.")
+            print("Error encountered; filesystem operation aborted.")
 
         return p.returncode
-

--- a/src/robot_upstart/providers.py
+++ b/src/robot_upstart/providers.py
@@ -36,9 +36,9 @@ from catkin.find_in_workspaces import find_in_workspaces
 
 
 def detect_provider():
-    cmd = open('/proc/1/cmdline', 'rb').read().split('\x00')[0]
+    cmd = open('/proc/1/cmdline', 'rb').read().split(b'\x00')[0]
     print (os.path.realpath(cmd))
-    if 'systemd' in os.path.realpath(cmd):
+    if b'systemd' in os.path.realpath(cmd):
         return Systemd
     return Upstart
 

--- a/src/robot_upstart/providers.py
+++ b/src/robot_upstart/providers.py
@@ -37,7 +37,7 @@ from catkin.find_in_workspaces import find_in_workspaces
 
 def detect_provider():
     cmd = open('/proc/1/cmdline', 'rb').read().split(b'\x00')[0]
-    print (os.path.realpath(cmd))
+    print(os.path.realpath(cmd))
     if b'systemd' in os.path.realpath(cmd):
         return Systemd
     return Upstart

--- a/src/robot_upstart/uninstall_script.py
+++ b/src/robot_upstart/uninstall_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (BSD)
 #
 # @author    Mike Purvis <mpurvis@clearpathrobotics.com>

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import em
 import os


### PR DESCRIPTION
To be able to use upstart on my RPI4 running ubuntu server 20.04 with only python3 installed I had to apply these changes. 

I changed from pickle to json as pickle created zero-bytes in the file, which gives error when provided as a cmd argument. 

I just wanted let you know this is how I solved it, if anyone else have the same issue as I did. 

This would partly solve #94 