### PR TITLE
WIP: Option to disable service for systemd.

### DIFF
--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -45,6 +45,7 @@ def get_argument_parser():
     p.add_argument("pkgpath", type=str, nargs='+', metavar="pkg/path",
                    help="Package and path to install job launch files from. " +
                         DESC_PKGPATH)
+    p.add_argument("--disable", action='store_true', help="If set, disable by not placing systemd's unit files. Ignored for upstart.")
     p.add_argument("--job", type=str,
                    help="Specify job name. If unspecified, will be constructed from package name (first " +
                    "element before underscore is taken, e.g. 'myrobot' if the package name is 'myrobot_bringup').")


### PR DESCRIPTION
# Status of PR

WIP, as it is untested yet.

# Problem

When provider is set to `systemd`, robot_upstart doesn't start the installed systemd unit and instead it only shows a comment to start manually, which I find is nice. However, (I guess by placing a unit file under `/lib/systemd/system`?) that unit is already enabled. So when the next time OS is rebooted, the systemd service in question starts. Sometimes this is not desired. User might want to get a control on whether the service is enabled or not.

# Change in this PR

- Add `disable` option, with which set to true the systemd unit gets "installed" but disabled so the service won't start before it's explicitly enabled.

# Open question
- Do we need to implement that for `upstart`?
   - Should upstart be still supported? This PR is targeted kinetic branch.