### PR TITLE
Melodic branch using setpriv

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,11 +14,11 @@ It's important to understand how permissions work robot_upstart:
 
 1. The upstart job invokes its `jobname-start` bash script as root.
 
-2. The script sets up environment variables, and then uses setuidgid_ to execute roslaunch as an unprivileged user. This is by default the user who ran the install script, but it can also be specified explicitly via a flag.
+2. The script sets up environment variables, and then uses setpriv_ to execute roslaunch as an unprivileged user. This is by default the user who ran the install script, but it can also be specified explicitly via a flag.
 
-3. The `roslaunch` which executes *does not have its user's group memberships*. This means that it will not have access to serial ports with the `dialout` group, or locations in `/var/log` owned by root, etc. Any filesystem resources needed by your ROS nodes should be chowned to the same unprivileged user which will run ROS, or should set to world readable/writeable, for example using udev. 
+3. The `roslaunch` which executes preserves its user's group memberships.  This means that the user should be configured to be a member of any applicable groups required by the ROS nodes being launched.  This will commonly include the `dialout` and `plugdev` groups for serial devices, and `audio` for speakers and microphones.  Any filesystem resources needed by your ROS nodes should be chowned and chmodded to be accessible to the same unprivileged user which will run ROS.
 
-.. _setuidgid: http://manpages.ubuntu.com/manpages/trusty/man8/setuidgid.8.html 
+.. _setpriv: https://man7.org/linux/man-pages/man1/setpriv.1.html
 
 Implementation
 --------------

--- a/templates/job-start.em
+++ b/templates/job-start.em
@@ -104,7 +104,7 @@ if [ "$?" != "0" ]; then
 fi
 
 # Punch it.
-setpriv --ruid @(user) --rgid @(user) --init-groups $LAUNCH_FILENAME @(roslaunch_wait?'--wait ')&
+setpriv --reuid @(user) --regid @(user) --init-groups $LAUNCH_FILENAME @(roslaunch_wait?'--wait ')&
 PID=$!
 
 log info "@(name): Started roslaunch as background process, PID $PID, ROS_LOG_DIR=$ROS_LOG_DIR"

--- a/templates/job-start.em
+++ b/templates/job-start.em
@@ -96,15 +96,15 @@ if [[ "$?" != "0" ]]; then
 fi
 log info "@(name): Generated launchfile: $LAUNCH_FILENAME"
 
-# Warn and exit if setuidgid is missing from the system.
-which setuidgid > /dev/null
+# Warn and exit if setpriv is missing from the system.
+which setprov > /dev/null
 if [ "$?" != "0" ]; then
-  log err "@(name): Can't launch as unprivileged user without setuidgid. Please install daemontools package."
+  log err "@(name): Can't launch as unprivileged user without setpriv. Please install the setpriv package."
   exit 1
 fi
 
 # Punch it.
-setuidgid @(user) roslaunch $LAUNCH_FILENAME @(roslaunch_wait?'--wait ')&
+setpriv --ruid @(user) --rgid @(user) --init-groups $LAUNCH_FILENAME @(roslaunch_wait?'--wait ')&
 PID=$!
 
 log info "@(name): Started roslaunch as background process, PID $PID, ROS_LOG_DIR=$ROS_LOG_DIR"

--- a/templates/job-start.em
+++ b/templates/job-start.em
@@ -97,7 +97,7 @@ fi
 log info "@(name): Generated launchfile: $LAUNCH_FILENAME"
 
 # Warn and exit if setpriv is missing from the system.
-which setprov > /dev/null
+which setpriv > /dev/null
 if [ "$?" != "0" ]; then
   log err "@(name): Can't launch as unprivileged user without setpriv. Please install the setpriv package."
   exit 1

--- a/templates/job-start.em
+++ b/templates/job-start.em
@@ -104,7 +104,7 @@ if [ "$?" != "0" ]; then
 fi
 
 # Punch it.
-setpriv --reuid @(user) --regid @(user) --init-groups $LAUNCH_FILENAME @(roslaunch_wait?'--wait ')&
+setpriv --reuid @(user) --regid @(user) --init-groups roslaunch $LAUNCH_FILENAME @(roslaunch_wait?'--wait ')&
 PID=$!
 
 log info "@(name): Started roslaunch as background process, PID $PID, ROS_LOG_DIR=$ROS_LOG_DIR"


### PR DESCRIPTION
This should _not_ be merged directly into kinetic-devel, but rather a new melodic-devel branch.

- Replaces setuidgid with setpriv to preserve group permissions
- setpriv is not available to be installed on 16.04 (though the package can be downloaded from 18.04 & manually installed on a 16.04 system), hence why this should be a new melodic branch.  setpriv is available on 18.04