### PR TITLE
Added model parameter to the install script

### DIFF
--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -73,6 +73,8 @@ def get_argument_parser():
                         "of the generated Systemd service file")
     p.add_argument("--model", type=str, metavar="MODEL", 
                    help="Specify the model of your robot if not specified under ROBOT_MODEL")
+    p.add_argument("--map_name", type=str, metavar="MODEL", 
+                   help="Specify the map name for your robot")
 
     return p
 

--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -71,6 +71,8 @@ def get_argument_parser():
     p.add_argument("--systemd-after", type=str, metavar="After=",
                    help="Set the string of the After= section"
                         "of the generated Systemd service file")
+    p.add_argument("--model", type=str, metavar="MODEL", 
+                   help="Specify the model of your robot if not specified under ROBOT_MODEL")
 
     return p
 
@@ -88,8 +90,7 @@ def main():
     j = robot_upstart.Job(
         name=job_name, interface=args.interface, user=args.user,
         workspace_setup=args.setup, rosdistro=args.rosdistro,
-        master_uri=args.master, log_path=args.logdir,
-        systemd_after=args.systemd_after)
+        master_uri=args.master, log_path=args.logdir, model=args.model, systemd_after=args.systemd_after)
 
     for this_pkgpath in args.pkgpath:
         pkg, pkgpath = this_pkgpath.split('/', 1)

--- a/src/robot_upstart/job.py
+++ b/src/robot_upstart/job.py
@@ -40,7 +40,7 @@ class Job(object):
     """ Represents a ROS configuration to launch on machine startup. """
 
     def __init__(self, name="ros", interface=None, user=None, workspace_setup=None,
-                 rosdistro=None, master_uri=None, log_path=None, model=None, systemd_after=None):
+                 rosdistro=None, master_uri=None, log_path=None, model=None, map_name=None, systemd_after=None):
         """Construct a new Job definition.
 
         :param name: Name of job to create. Defaults to "ros", but you might
@@ -120,6 +120,14 @@ class Job(object):
                 self.model = name.upper() + '_MODEL=' + os.environ[name.upper() + '_MODEL']
             except KeyError:
                 self.model = name.upper() + '_MODEL=ROBOT'
+
+        if map_name:
+            self.map_name = name.upper() + '_MAP=' + map_name
+        else:
+            try:
+                self.map_name = name.upper() + '_MAP=' + os.environ[name.upper() + '_MAP']
+            except KeyError:
+                self.map_name = name.upper() + '_MAP=ROBOT'
 
     def add(self, package=None, filename=None, glob=None):
         """ Add launch or other configuration files to Job.

--- a/src/robot_upstart/job.py
+++ b/src/robot_upstart/job.py
@@ -40,8 +40,7 @@ class Job(object):
     """ Represents a ROS configuration to launch on machine startup. """
 
     def __init__(self, name="ros", interface=None, user=None, workspace_setup=None,
-                 rosdistro=None, master_uri=None, log_path=None,
-                 systemd_after=None):
+                 rosdistro=None, master_uri=None, log_path=None, model=None, systemd_after=None):
         """Construct a new Job definition.
 
         :param name: Name of job to create. Defaults to "ros", but you might
@@ -68,6 +67,8 @@ class Job(object):
             default of using /tmp, it is the user's responsibility to manage log
             rotation.
         :type log_path: str
+        :param model: Your robot model if not specified under ROBOT_MODEL.
+        :type model: str
         """
 
         self.name = name
@@ -109,6 +110,16 @@ class Job(object):
         # and other user-specified configs--- nothing related to the system
         # startup job itself. List of strs.
         self.files = []
+
+        # Sets the model environment variable if provided, else results in
+        # ROBOT_MODEL=ROBOT
+        if model:
+            self.model = name.upper() + '_MODEL=' + model
+        else:    
+            try:
+                self.model = name.upper() + '_MODEL=' + os.environ[name.upper() + '_MODEL']
+            except KeyError:
+                self.model = name.upper() + '_MODEL=ROBOT'
 
     def add(self, package=None, filename=None, glob=None):
         """ Add launch or other configuration files to Job.

--- a/templates/job-start.em
+++ b/templates/job-start.em
@@ -70,6 +70,9 @@ export ROS_MASTER_URI=http://127.0.0.1:11311
 @[if model]@
 export @(model)
 @[end if]@
+@[if map_name]@
+export @(map_name)
+@[end if]@
 export ROS_HOME=${ROS_HOME:=$(echo ~@(user))/.ros}
 export ROS_LOG_DIR=$log_path
 

--- a/templates/job-start.em
+++ b/templates/job-start.em
@@ -67,6 +67,9 @@ export ROS_MASTER_URI=@(master_uri)
 @[else]@
 export ROS_MASTER_URI=http://127.0.0.1:11311
 @[end if]@
+@[if model]@
+export @(model)
+@[end if]@
 export ROS_HOME=${ROS_HOME:=$(echo ~@(user))/.ros}
 export ROS_LOG_DIR=$log_path
 


### PR DESCRIPTION
# Description
When starting different robots with the same bringup.launch file a model parameter can be used to specify the robot in question. For the turtlebot3 an environment variable TURTLEBOT3_MODEL is used with the values burger/waffle/waffle_pi.

This pull request adds the environment variable %PACKAGE_NAME%_MODEL to the install script and also to the start bash script.

# Example

` rosrun robot_upstart install --model pi myrobot_bringup/launch/base.launch `
results inside the start bash script to
`export MYROBOT_MODEL=pi`