### PR TITLE
 Enable customization of  After= in service

### DIFF
--- a/src/robot_upstart/install_script.py
+++ b/src/robot_upstart/install_script.py
@@ -68,6 +68,9 @@ def get_argument_parser():
                    help="Create symbolic link to job launch files instead of copying them.")
     p.add_argument("--wait", action='store_true',
                    help="Pass a wait flag to roslaunch.")
+    p.add_argument("--systemd-after", type=str, metavar="After=",
+                   help="Set the string of the After= section"
+                        "of the generated Systemd service file")
 
     return p
 
@@ -85,7 +88,8 @@ def main():
     j = robot_upstart.Job(
         name=job_name, interface=args.interface, user=args.user,
         workspace_setup=args.setup, rosdistro=args.rosdistro,
-        master_uri=args.master, log_path=args.logdir)
+        master_uri=args.master, log_path=args.logdir,
+        systemd_after=args.systemd_after)
 
     for this_pkgpath in args.pkgpath:
         pkg, pkgpath = this_pkgpath.split('/', 1)

--- a/src/robot_upstart/job.py
+++ b/src/robot_upstart/job.py
@@ -40,7 +40,8 @@ class Job(object):
     """ Represents a ROS configuration to launch on machine startup. """
 
     def __init__(self, name="ros", interface=None, user=None, workspace_setup=None,
-                 rosdistro=None, master_uri=None, log_path=None):
+                 rosdistro=None, master_uri=None, log_path=None,
+                 systemd_after=None):
         """Construct a new Job definition.
 
         :param name: Name of job to create. Defaults to "ros", but you might
@@ -99,6 +100,10 @@ class Job(object):
         # This will be desired if the nodes spawned by this job are intended to
         # connect to an existing master.
         self.roslaunch_wait = False
+
+        # Set the string of the "After=" section
+        # of the generated Systemd service file
+        self.systemd_after = systemd_after or "network.target"
 
         # Set of files to be installed for the job. This is only launchers
         # and other user-specified configs--- nothing related to the system

--- a/src/robot_upstart/providers.py
+++ b/src/robot_upstart/providers.py
@@ -151,7 +151,6 @@ class Upstart(Generic):
         with open(find_in_workspaces(project="robot_upstart", path=template)[0]) as f:
             self.interpreter.file(f)
             return self.interpreter.output.getvalue()
-        self.set_job_path()
 
 
 class Systemd(Generic):

--- a/src/robot_upstart/providers.py
+++ b/src/robot_upstart/providers.py
@@ -172,7 +172,7 @@ class Systemd(Generic):
         # This is optional to support the old --augment flag where a "job" only adds
         # launch files to an existing configuration.
         if self.job.generate_system_files:
-            # Share a single instance of the empy interpreter.
+            # Share a single instance of the empty interpreter.
             self.interpreter = em.Interpreter(globals=self.job.__dict__.copy())
 
             self.installation_files[os.path.join(self.root, "lib/systemd/system", self.job.name + ".service")] = {

--- a/src/robot_upstart/providers.py
+++ b/src/robot_upstart/providers.py
@@ -171,7 +171,7 @@ class Systemd(Generic):
 
         # This is optional to support the old --augment flag where a "job" only adds
         # launch files to an existing configuration.
-        if (self.job.generate_system_files):
+        if self.job.generate_system_files:
             # Share a single instance of the empy interpreter.
             self.interpreter = em.Interpreter(globals=self.job.__dict__.copy())
 

--- a/templates/systemd_job.conf.em
+++ b/templates/systemd_job.conf.em
@@ -29,7 +29,7 @@
 
 [Unit]
 Description="bringup @(name)"
-After=network.target
+After=@(systemd_after)
 
 [Service]
 Type=simple


### PR DESCRIPTION
This feature enables the user to define the services after which the generated
service will. This is handy when hardware-related system services have
to start before the ROS software.