### PR TITLE
Use setpriv instead of setuidgid

### DIFF
--- a/templates/job-start.em
+++ b/templates/job-start.em
@@ -96,15 +96,15 @@ if [[ "$?" != "0" ]]; then
 fi
 log info "@(name): Generated launchfile: $LAUNCH_FILENAME"
 
-# Warn and exit if setuidgid is missing from the system.
-which setuidgid > /dev/null
+# Warn and exit if setpriv is missing from the system.
+which setpriv > /dev/null
 if [ "$?" != "0" ]; then
-  log err "@(name): Can't launch as unprivileged user without setuidgid. Please install daemontools package."
+  log err "@(name): Can't launch as unprivileged user without setpriv. Please install the setpriv package."
   exit 1
 fi
 
 # Punch it.
-setuidgid @(user) roslaunch $LAUNCH_FILENAME @(roslaunch_wait?'--wait ')&
+setpriv --reuid @(user) --regid @(user) --init-groups roslaunch $LAUNCH_FILENAME @(roslaunch_wait?'--wait ')&
 PID=$!
 
 log info "@(name): Started roslaunch as background process, PID $PID, ROS_LOG_DIR=$ROS_LOG_DIR"


### PR DESCRIPTION
Replicates change from melodic-devel.  Setpriv allows use of group permissions, reducing the need to globally apply r/w permissions to devices.