### PR TITLE
Make tests pass on ROS 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,24 @@ jobs:
     name: Jazzy
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: jazzy
-      - uses: ros-tooling/action-ros-ci@v0.3
-        id: action_ros_ci_step
-        with:
-          target-ros2-distro: jazzy
-          import-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name:
-            robot_upstart
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Create Workspace
+        run: |
+          mkdir src_tmp
+          mv `find -maxdepth 1 -not -name . -not -name src_tmp` src_tmp/
+          mv src_tmp/ src/
+      - name: Install Prerequisites
+        run: |
+          bash -c 'source /opt/ros/$ROS_DISTRO/setup.bash; \
+          apt-get update && apt-get upgrade -y && rosdep update; \
+          rosdep install --from-paths src --ignore-src -y'
+      - name: Build Workspace
+        run: |
+          bash -c 'source /opt/ros/$ROS_DISTRO/setup.bash; \
+          colcon build'
+      - name: Run Tests
+        run: |
+          bash -c 'source /opt/ros/$ROS_DISTRO/setup.bash; \
+          colcon test; \
+          colcon test-result --verbose'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: robot_upstart_ci
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [foxy-devel]
+  pull_request:
+    branches: [foxy-devel]
 
 jobs:
   jazzy_ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ jobs:
   jazzy_ci:
     name: Jazzy
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+    container:
+      image: osrf/ros2:testing
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,37 @@ jobs:
           skip-tests: false
           package-name:
             robot_upstart
+
+  humble_ci:
+    name: Humble
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
+      - uses: ros-tooling/action-ros-ci@v0.3
+        id: action_ros_ci_step
+        with:
+          target-ros2-distro: humble
+          import-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-tests: false
+          package-name:
+            robot_upstart
+
+  foxy_ci:
+    name: Foxy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: foxy
+      - uses: ros-tooling/action-ros-ci@v0.3
+        id: action_ros_ci_step
+        with:
+          target-ros2-distro: foxy
+          import-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-tests: false
+          package-name:
+            robot_upstart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,20 +36,3 @@ jobs:
           skip-tests: false
           package-name:
             robot_upstart
-
-  foxy_ci:
-    name: Foxy
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: foxy
-      - uses: ros-tooling/action-ros-ci@v0.3
-        id: action_ros_ci_step
-        with:
-          target-ros2-distro: foxy
-          import-token: ${{ secrets.GITHUB_TOKEN }}
-          skip-tests: false
-          package-name:
-            robot_upstart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,29 +6,16 @@ jobs:
   jazzy_ci:
     name: Jazzy
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-    container:
-      image: osrf/ros2:testing
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Create Workspace
-        run: |
-          mkdir src_tmp
-          mv `find -maxdepth 1 -not -name . -not -name src_tmp` src_tmp/
-          mv src_tmp/ src/
-      - name: Install Prerequisites
-        run: |
-          bash -c 'source /opt/ros/$ROS_DISTRO/setup.bash; \
-          apt-get update && apt-get upgrade -y && rosdep update; \
-          rosdep install --from-paths src --ignore-src -y'
-      - name: Build Workspace
-        run: |
-          bash -c 'source /opt/ros/$ROS_DISTRO/setup.bash; \
-          colcon build'
-      - name: Run Tests
-        run: |
-          bash -c 'source /opt/ros/$ROS_DISTRO/setup.bash; \
-          colcon test; \
-          colcon test-result --verbose'
+      - uses: actions/checkout@v2.3.4
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
+      - uses: ros-tooling/action-ros-ci@v0.3
+        id: action_ros_ci_step
+        with:
+          target-ros2-distro: jazzy
+          import-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-tests: false
+          package-name:
+            robot_upstart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: robot_upstart_ci
+
+on: [push, pull_request]
+
+jobs:
+  jazzy_ci:
+    name: Jazzy
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
+      - uses: ros-tooling/action-ros-ci@v0.3
+        id: action_ros_ci_step
+        with:
+          target-ros2-distro: jazzy
+          import-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name:
+            robot_upstart

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-robot_upstart [![Build Status](https://travis-ci.org/clearpathrobotics/robot_upstart.svg?branch=jade-devel)](https://travis-ci.org/clearpathrobotics/robot_upstart)
-=============
+# robot_upstart [![robot_upstart_ci](https://github.com/clearpathrobotics/robot_upstart/actions/workflows/ci.yml/badge.svg?branch=foxy-devel)](https://github.com/clearpathrobotics/robot_upstart/actions/workflows/ci.yml)
 
 Clearpath Robotics presents a suite of scripts to assist with launching background ROS processes on Ubuntu Linux PCs. Please see the [generated documentation](http://docs.ros.org/latest-available/api/robot_upstart/html/) and [ROS Wiki](http://wiki.ros.org/robot_upstart).

--- a/robot_upstart/job.py
+++ b/robot_upstart/job.py
@@ -82,12 +82,17 @@ class Job(object):
         # Fall back on current user as the user to run ROS as.
         self.user = user or getpass.getuser()
 
-        # Fall back on current workspace setup file if not explicitly specified.
-        self.workspace_setup = workspace_setup or \
-            os.environ['CMAKE_PREFIX_PATH'].split(':')[0] + '/../setup.bash'
-
         # Fall back on current distro if not otherwise specified.
         self.rosdistro = rosdistro or os.environ['ROS_DISTRO']
+
+        # Prioritize specified workspace, falling back to current workspace if possible, or
+        # system workspace as a last-resort
+        if workspace_setup:
+            self.workspace_setup = workspace_setup
+        elif 'CMAKE_PREFIX_PATH' in os.environ.keys():
+            self.workspace_setup = os.environ['CMAKE_PREFIX_PATH'].split(':')[0] + '/../setup.bash'
+        else:
+            self.workspace_setup = f'/opt/ros/{self.rosdistro}/setup.bash'
 
         self.rmw = rmw or "rmw_fastrtps_cpp"
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ setup(
         (os.path.join('lib', PACKAGE_NAME, 'scripts'), glob('scripts/*')),
         (os.path.join('share', PACKAGE_NAME, 'scripts'), glob('scripts/*')),
         (os.path.join('share', PACKAGE_NAME, 'templates'), glob('templates/*')),
+        (os.path.join('share', PACKAGE_NAME, 'test'), glob('test/*.py')),
+        (os.path.join('share', PACKAGE_NAME, 'test/launch'), glob('test/launch/*.launch')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -32,7 +32,12 @@ class TestBasics(unittest.TestCase):
 
         self.assertTrue(os.path.exists(self.pjoin("usr/sbin/foo-start")), "Start script not created.")
         self.assertTrue(os.path.exists(self.pjoin("usr/sbin/foo-stop")), "Stop script not created.")
-        self.assertTrue(os.path.exists(self.pjoin("etc/init/foo.conf")), "Upstart configuration file not created.")
+
+        # Systemd config
+        self.assertTrue(os.path.exists(self.pjoin("etc/systemd/system/multi-user.target.wants/foo.service")), "Systemd service file not created.")
+
+        # Upstart config
+        #self.assertTrue(os.path.exists(self.pjoin("etc/init/foo.conf")), "Upstart configuration file not created.")
 
         self.assertEqual(0, subprocess.call(["bash", "-n", self.pjoin("usr/sbin/foo-start")]),
                          "Start script not valid bash syntax.")


### PR DESCRIPTION
Tested on Jazzy.  Tests are now passing (on my machine at least).  Necessary changes:
1. Add `test.launch/*.launch` to the installed files; otherwise the `Job` object cannot locate the launch files to install
2. Replace check for `upstart` configuration file with newer `systemd` configuration file

I'd appreciate someone running the tests on different machines and different ROS distributions to make sure the changes work on those too before we release an updated version.

General testing process:
```
cd /path/to/workspace
rm -rf install/robot_upstart
colcon build --packages-select robot_upstart
colcon test --packages-select robot_upstart
cat log/latest_test/robot_upstart/stdout.log
```

Make sure the log doesn't show any assertion failures. Assuming there aren't any we should be in good shape.