### PR TITLE
Fix failing tests on buildfarm

### DIFF
--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -10,6 +10,8 @@ import unittest
 import robot_upstart
 
 
+ROS_DISTRO = os.getenv("ROS_DISTRO", "jazzy")
+
 class TestBasics(unittest.TestCase):
 
     def setUp(self):
@@ -49,9 +51,9 @@ class TestBasics(unittest.TestCase):
         j.add('robot_upstart', 'test/launch/a.launch')
         j.install(sudo=None, root=self.root_dir)
 
-        self.assertTrue(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "bar.d/a.launch")),
+        self.assertTrue(os.path.exists(self.pjoin("etc/ros", ROS_DISTRO, "bar.d/a.launch")),
                         "Launch file not copied.")
-        self.assertFalse(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "bar.d/b.launch")),
+        self.assertFalse(os.path.exists(self.pjoin("etc/ros", ROS_DISTRO, "bar.d/b.launch")),
                          "Launch copied which shouldn't have been.")
 
     def test_install_glob(self):
@@ -59,9 +61,9 @@ class TestBasics(unittest.TestCase):
         j.add('robot_upstart', glob='test/launch/*.launch')
         j.install(sudo=None, root=self.root_dir)
 
-        self.assertTrue(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "baz.d/a.launch")),
+        self.assertTrue(os.path.exists(self.pjoin("etc/ros", ROS_DISTRO, "baz.d/a.launch")),
                         "Launch file not copied.")
-        self.assertTrue(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "baz.d/b.launch")),
+        self.assertTrue(os.path.exists(self.pjoin("etc/ros", ROS_DISTRO, "baz.d/b.launch")),
                         "Launch file not copied.")
 
     def test_uninstall(self):
@@ -70,20 +72,20 @@ class TestBasics(unittest.TestCase):
         j.install(sudo=None, root=self.root_dir)
         j.uninstall(sudo=None, root=self.root_dir)
 
-        self.assertFalse(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "boo.d")),
+        self.assertFalse(os.path.exists(self.pjoin("etc/ros", ROS_DISTRO, "boo.d")),
                          "Job dir not removed.")
-        self.assertFalse(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "usr/sbin/foo-start")),
+        self.assertFalse(os.path.exists(self.pjoin("etc/ros", ROS_DISTRO, "usr/sbin/foo-start")),
                          "Start script not removed.")
 
     def test_uninstall_user_file(self):
         j = robot_upstart.Job(name="goo")
         j.add('robot_upstart', glob='test/launch/*.launch')
         j.install(sudo=None, root=self.root_dir)
-        with open(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "goo.d/c.launch"), "w") as f:
+        with open(self.pjoin("etc/ros", ROS_DISTRO, "goo.d/c.launch"), "w") as f:
             f.write("<launch></launch>")
         j.uninstall(sudo=None, root=self.root_dir)
 
-        self.assertTrue(os.path.exists(self.pjoin("etc/ros", os.getenv("ROS_DISTRO"), "goo.d/c.launch")),
+        self.assertTrue(os.path.exists(self.pjoin("etc/ros", ROS_DISTRO, "goo.d/c.launch")),
                         "User launch file wrongly removed.")
 
 

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -29,7 +29,7 @@ class TestBasics(unittest.TestCase):
         return os.path.join(self.root_dir, *p)
 
     def test_install(self):
-        j = robot_upstart.Job(name="foo")
+        j = robot_upstart.Job(name="foo", rosdistro=ROS_DISTRO)
         j.install(sudo=None, root=self.root_dir)
 
         self.assertTrue(os.path.exists(self.pjoin("usr/sbin/foo-start")), "Start script not created.")
@@ -47,7 +47,7 @@ class TestBasics(unittest.TestCase):
                          "Stop script not valid bash syntax.")
 
     def test_install_launcher(self):
-        j = robot_upstart.Job(name="bar")
+        j = robot_upstart.Job(name="bar", rosdistro=ROS_DISTRO)
         j.add('robot_upstart', 'test/launch/a.launch')
         j.install(sudo=None, root=self.root_dir)
 
@@ -57,7 +57,7 @@ class TestBasics(unittest.TestCase):
                          "Launch copied which shouldn't have been.")
 
     def test_install_glob(self):
-        j = robot_upstart.Job(name="baz")
+        j = robot_upstart.Job(name="baz", rosdistro=ROS_DISTRO)
         j.add('robot_upstart', glob='test/launch/*.launch')
         j.install(sudo=None, root=self.root_dir)
 
@@ -67,7 +67,7 @@ class TestBasics(unittest.TestCase):
                         "Launch file not copied.")
 
     def test_uninstall(self):
-        j = robot_upstart.Job(name="boo")
+        j = robot_upstart.Job(name="boo", rosdistro=ROS_DISTRO)
         j.add('robot_upstart', glob='test/launch/*.launch')
         j.install(sudo=None, root=self.root_dir)
         j.uninstall(sudo=None, root=self.root_dir)
@@ -78,7 +78,7 @@ class TestBasics(unittest.TestCase):
                          "Start script not removed.")
 
     def test_uninstall_user_file(self):
-        j = robot_upstart.Job(name="goo")
+        j = robot_upstart.Job(name="goo", rosdistro=ROS_DISTRO)
         j.add('robot_upstart', glob='test/launch/*.launch')
         j.install(sudo=None, root=self.root_dir)
         with open(self.pjoin("etc/ros", ROS_DISTRO, "goo.d/c.launch"), "w") as f:


### PR DESCRIPTION
Tests on the build farm are failing with e.g.
```
20:49:15 ___________________________ TestBasics.test_install ____________________________
20:49:15 test/test_basics.py:30: in test_install
20:49:15     j = robot_upstart.Job(name="foo")
20:49:15 robot_upstart/job.py:86: in __init__
20:49:15     self.rosdistro = rosdistro or os.environ['ROS_DISTRO']
20:49:15 /usr/lib/python3.10/os.py:680: in __getitem__
20:49:15     raise KeyError(key) from None
20:49:15 E   KeyError: 'ROS_DISTRO'
```

Adding a fallback to the tests & explicitly passing the value for the `rosdistro` parameter should resolve this.

See RPSW-1768.